### PR TITLE
fix: specify badge background color

### DIFF
--- a/src/background/background-utils.ts
+++ b/src/background/background-utils.ts
@@ -106,6 +106,9 @@ export const updateBadge = async (badgeNumber: number): Promise<void> => {
   chrome.action.setBadgeText({
     text: `${badgeNumber}`,
   });
+
+  // Specify background and text color (necessary for Chrome ~102+)
+  chrome.action.setBadgeBackgroundColor({ color: '#0000FF' });
 };
 
 interface BadgeNotificationResult {


### PR DESCRIPTION
A recent Chrome update appears to have changed the original (default) blue background color.